### PR TITLE
Fix crash when baby petz's from older versions are placed

### DIFF
--- a/petz/api/api_breed.lua
+++ b/petz/api/api_breed.lua
@@ -128,6 +128,9 @@ petz.pregnant_timer = function(self, dtime)
 end
 
 petz.growth_timer = function(self, dtime)
+	if(not(self.growth_time)) then
+		self.growth_time = 0
+	end 
 	self.growth_time = mobkit.remember(self, "growth_time", self.growth_time + dtime)
 	if self.growth_time >= petz.settings.growth_time then
 		self.is_baby = mobkit.remember(self, "is_baby", false)


### PR DESCRIPTION
When baby petz that were bred in much older versions are placed, that are missing that metadata, they crash the server.
This seems to fix it, by making a check for it.