### PR TITLE
bonemeal now uses groups for recipes

### DIFF
--- a/petz/misc/bonemeal.lua
+++ b/petz/misc/bonemeal.lua
@@ -2,26 +2,14 @@
 
 minetest.register_craft({
 	type = "shapeless",
-	output = "bonemeal:bonemeal",
-	recipe = {"petz:bone"},
-})
-
-minetest.register_craft({
-	output = "bonemeal:gelatin_powder 4",
-	recipe = {
-			{"petz:bone", "petz:bone", "petz:bone"},
-			{"bucket:bucket_water", "bucket:bucket_water", "bucket:bucket_water"},
-			{"bucket:bucket_water", "default:torch", "bucket:bucket_water"},
-	},
-	replacements = {
-		{"bucket:bucket_water", "bucket:bucket_empty 5"},
-	},
+	output = "petz:bone 2",
+	recipe = {"bonemeal:bone","bonemeal:bone"},
 })
 
 minetest.register_craft({
 	type = "shapeless",
-	output = "petz:bone 2",
-	recipe = {"bonemeal:bone"},
+	output = "bonemeal:bone 2",
+	recipe = {"petz:bone", "petz:bone"},
 })
 
 minetest.register_craft({


### PR DESCRIPTION
Bonemeal mod has been updated to use group:bone in recipes.
Petz doesn't need to redefine recipes anymore.

I added the ability to convert seamlessly petz:bone <-> bonemal:bone