### PR TITLE
fix crash when placing bottled mob via `minetest.place_node`

### DIFF
--- a/petz/misc/items.lua
+++ b/petz/misc/items.lua
@@ -403,7 +403,7 @@ for i=1, 2 do
 			local meta = minetest.get_meta(pos)
 			--meta = meta_itemstack
 			local placer_name = ""
-			if placer:is_player() then
+			if minetest.is_player(placer) then
 				placer_name = placer:get_player_name()
 			end
 			meta:set_string("owner", placer_name)


### PR DESCRIPTION
use `minetest.is_player` instead of `placer:is_player` in case the placer is nil. Fixes a crash e.g.

```
2022-05-29 12:12:55: ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod '' in callback LuaABM::trigger(): Runtime error from mod '' in callback item_OnPlace(): ...n/worldmods/petz/petz/misc/items.lua:406: attempt to index local 'placer' (a nil value)
2022-05-29 12:12:55: ERROR[Main]: stack traceback:
2022-05-29 12:12:55: ERROR[Main]: 	...n/../worlds/your-land/worldmods/petz/petz/misc/items.lua:406: in function 'after_place_node'
2022-05-29 12:12:55: ERROR[Main]: 	/opt/minetest/bin/../builtin/game/item.lua:267: in function </opt/minetest/bin/../builtin/game/item.lua:146>
2022-05-29 12:12:55: ERROR[Main]: 	[C]: in function 'place_node'
```