### PR TITLE
change grain packet recipe not to overlap bonemeal mulch group:seed recipe

### DIFF
--- a/petz/misc/nodes.lua
+++ b/petz/misc/nodes.lua
@@ -737,7 +737,7 @@ minetest.register_craft({
 	output = "petz:grain_packet",
 	recipe = {
 		"farming:seed_wheat", "farming:seed_wheat", "farming:seed_wheat",
-		"farming:seed_wheat", "farming:seed_wheat", "farming:seed_wheat",
+		"farming:seed_wheat",                   "", "farming:seed_wheat",
 		"farming:seed_wheat", "farming:seed_wheat", "farming:seed_wheat"
 	}
 })


### PR DESCRIPTION
Seems that something went wrong in your way to solve this issue in this commit: [solved: the recipe for grain_packet conflicts with the recipe for bonemeal:mulch](https://github.com/runsy/petz/commit/f48925a3acf15253db5d6ac8e96060ab827fe3c8)
It does not touch the grain_packet recipe at all, so I just re-open a new PR as it seems you intended to merge fix.