### PR TITLE
Grain Packet: do not use shapeless recipe, sorry

### DIFF
--- a/petz/misc/nodes.lua
+++ b/petz/misc/nodes.lua
@@ -733,11 +733,10 @@ minetest.register_node("petz:grain_packet", {
 })
 
 minetest.register_craft({
-	type = "shapeless",
 	output = "petz:grain_packet",
 	recipe = {
-		"farming:seed_wheat", "farming:seed_wheat", "farming:seed_wheat",
-		"farming:seed_wheat",                   "", "farming:seed_wheat",
-		"farming:seed_wheat", "farming:seed_wheat", "farming:seed_wheat"
+		{ "farming:seed_wheat", "farming:seed_wheat", "farming:seed_wheat" },
+		{ "farming:seed_wheat",                   "", "farming:seed_wheat" },
+		{ "farming:seed_wheat", "farming:seed_wheat", "farming:seed_wheat" }
 	}
 })


### PR DESCRIPTION
Sorry I forgot to remove type="shapeless" when changing grain_packet recipe