### PR TITLE
Arboreal: climb only if not placed by player

### DIFF
--- a/petz/brains/bh_arboreal.lua
+++ b/petz/brains/bh_arboreal.lua
@@ -3,14 +3,14 @@
 --
 
 function petz.check_tree(self)
-	local node_front_name = petz.node_name_in(self, "front")
+	local node_front_name, _, node = petz.node_name_in(self, "front")
 	--minetest.chat_send_player("singleplayer", node_front_name)
-	local node_top_name= petz.node_name_in(self, "top")
+	local node_top_name = petz.node_name_in(self, "top")
 	--minetest.chat_send_player("singleplayer", node_top_name)
 	if node_front_name and minetest.registered_nodes[node_front_name]
-		and petz.is_tree_like(node_front_name)
 		and node_top_name and minetest.registered_nodes[node_top_name]
-		and node_top_name == "air" then
+		and node_top_name == "air"
+		and petz.is_tree_like(node) then
 			return true
 	else
 		return false
@@ -18,8 +18,8 @@ function petz.check_tree(self)
 end
 
 function petz.is_tree_like(node)
-	if minetest.registered_nodes[node].groups.leaves
-			or minetest.registered_nodes[node].groups.tree then
+	if minetest.registered_nodes[node.name].groups.leaves
+			or ( node.param1 == 0 and minetest.registered_nodes[node.name].groups.tree ) then
 				return true
 	else
 		return false

--- a/petz/brains/helper_functions.lua
+++ b/petz/brains/helper_functions.lua
@@ -193,7 +193,7 @@ function petz.node_name_in(self, where)
 		end
 		local node = minetest.get_node_or_nil(pos2)
 		if node and minetest.registered_nodes[node.name] then
-			return node.name, pos2
+			return node.name, pos2, node
 		else
 			return nil
 		end


### PR DESCRIPTION
I most cases chimps/squirrels ... are not supposed to climb walls or palisades placed by player when they are made out of "group:tree".

[Lumberjack](https://github.com/joe7575/lumberjack) mod check difference between natural trees (those placed at mapgen, or trees grown from sapling) and artificial trees with param1. When param1 == 0 it is supposed to be a tree placed via api.

I added  node itself to petz.node_name_in return values
In petz.check_tree I retrieved the node data for "front"
In petz.is_tree_like I check node.param1 == 0 for "group:tree" so arboreal will not be able to climb tree walls.