### PR TITLE
Egg count

### DIFF
--- a/petz/api/api_eggs.lua
+++ b/petz/api/api_eggs.lua
@@ -8,12 +8,12 @@ petz.lay_egg = function(self)
 	if self.eggs_count >= max_laid_eggs then
 		return
 	end
-	if petz.isinliquid(self) then --do not put eggs when in liquid
-		return
-	end
 	local pos = self.object:get_pos()
 	local laid_egg = false
 	if self.lay_eggs == "item" or self.lay_eggs == "node" then
+		if petz.isinliquid(self) then --do not put eggs when in liquid
+			return
+		end
 		if petz.limit_reached(pos, nil, self.type) then
 			return
 		end

--- a/petz/settings.lua
+++ b/petz/settings.lua
@@ -563,7 +563,7 @@ for i = 1, #petz.settings["petz_list"] do --load the settings
 	petz.settings[petz_type.."_lifetime"] = tonumber(user:get(petz_type.."_lifetime") or settings:get(petz_type.."_lifetime")) or nil
 	petz.settings[petz_type.."_disable_spawn"] = user:get_bool(petz_type.."_disable_spawn")
 	petz.settings[petz_type.."_max_laid_eggs"] = tonumber(user:get(petz_type.."_max_laid_eggs")
-		or settings:get(petz_type.."_max_laid_eggs")) or 2.0
+		or settings:get(petz_type.."_max_laid_eggs")) or nil
 	if petz.settings[petz_type.."_disable_spawn"] == nil then
 		petz.settings[petz_type.."_disable_spawn"] = settings:get_bool(petz_type.."_disable_spawn", false)
 	end


### PR DESCRIPTION
Max egg for chicken is set to 2 because of the or 2.0 in settings.lua.
as a result chicken can not lay more than 2 eggs and population does not seem to increase.

About the ability to drop egg to nest when they are really close but in water I'm not really sure what to think.

I'm also thinking that petz with type "nest_egg" should have a timer not allowing them to drop an egg before "some" time

