### PR TITLE
werewolf damage reduction changes

### DIFF
--- a/petz/petz.conf
+++ b/petz/petz.conf
@@ -194,6 +194,7 @@ worker_bee_delay = 300
 lycanthropy = true
 lycanthropy_infection_chance_by_wolf = 200
 lycanthropy_infection_chance_by_werewolf = 10
+lycanthropy_werewolf_damage_reduction = 0.5
 
 ##Damage Engine
 #If this setting is 'true', checks the "enable_damage" setting of the game

--- a/petz/settings.lua
+++ b/petz/settings.lua
@@ -478,6 +478,11 @@ local settings_def = {
 	type = "number",
 	default = 10,
 	},
+	{
+	name = "lycanthropy_werewolf_damage_reduction",
+	type = "number",
+	default = 0.5,
+	},
 	--Server Cron Tasks
 	{
 	name = "clear_mobs_time",


### PR DESCRIPTION
currently, the werewolf damage reduction mechanism, which overrides behavior using `minetest.register_on_punchplayer`, breaks compatibility w/ mods like pvpplus, which prevents damage unless both the attacker and the target have pvp enabled. 

this update fixes this by instead using the `minetest.register_on_player_hpchange` callback. while i was doing this, i also added a setting to allow adjusting the werewolf damage reduction amount.