### PR TITLE
prevent werewolves from eating raw meat if hbhunger *isn't* installed

### DIFF
--- a/petz/misc/lycanthropy.lua
+++ b/petz/misc/lycanthropy.lua
@@ -384,7 +384,7 @@ minetest.register_on_joinplayer(
 -- A werewolf only can eat raw meat
 --
 
-if minetest.get_modpath("hbhunger") then
+if not minetest.get_modpath("hbhunger") then
 	minetest.register_on_item_eat(
 		function(hp_change, replace_with_item, itemstack, user, pointed_thing)
 			if petz.is_werewolf(user) and (minetest.get_item_group(itemstack:get_name(), "food_meat_raw") == 0) then

--- a/petz/misc/lycanthropy.lua
+++ b/petz/misc/lycanthropy.lua
@@ -393,7 +393,7 @@ if not minetest.get_modpath("hbhunger") then
 				minetest.chat_send_player(user_name, S("Werewolves only can eat raw meat!"))
 				return itemstack
 			end
-    end
+    	end
 	)
 end
 


### PR DESCRIPTION
when i was doing updates to the werewolf previously, i accidentally negated the check for hbhunger when preventing players from eating anything other than raw meat. this fixes that. 