### PR TITLE
add nil checks after minetest.add_entity and minetest.add_item, where appropriate

### DIFF
--- a/petz/api/api_bees.lua
+++ b/petz/api/api_bees.lua
@@ -172,11 +172,13 @@ minetest.register_node("petz:beehive", {
 				local spawn_bee_pos = petz.spawn_bee_pos(pos)
 				if spawn_bee_pos then
 					local bee = minetest.add_entity(spawn_bee_pos, "petz:bee")
-					local bee_entity = bee:get_luaentity()
-					bee_entity.beehive = kitz.remember(bee_entity, "beehive", pos)
-					bee_count = bee_count - 1
-					meta:set_int("bee_count", bee_count)
-					petz.set_infotext_beehive(meta, honey_count, bee_count)
+					if bee then
+						local bee_entity = bee:get_luaentity()
+						bee_entity.beehive = kitz.remember(bee_entity, "beehive", pos)
+						bee_count = bee_count - 1
+						meta:set_int("bee_count", bee_count)
+						petz.set_infotext_beehive(meta, honey_count, bee_count)
+					end
 				end
 			end
 		end

--- a/petz/api/api_convert.lua
+++ b/petz/api/api_convert.lua
@@ -7,15 +7,17 @@ petz.convert = function(self, player_name)
 	if self.convert_count <= 0 then
 		local pos = self.object:get_pos()
 		local converted_pet = minetest.add_entity(pos, petz.settings[self.type.."_convert_to"])
-		kitz.make_sound("object", converted_pet, "petz_pop_sound", petz.settings.max_hear_distance)
-		local converted_entity = converted_pet:get_luaentity()
-		converted_entity.tamed = true
-		kitz.remember(converted_entity, "tamed", converted_entity.tamed)
-		converted_entity.owner = player_name
-		kitz.remember(converted_entity, "owner", converted_entity.owner)
-		kitz.remove_mob(self)
-		local new_pet_name = petz.first_to_upper(converted_entity.type)
-		minetest.chat_send_player(player_name , S("The").." "..S(old_pet_name).." "..S("turn into").." "..S(new_pet_name))
+		if converted_pet then
+			kitz.make_sound("object", converted_pet, "petz_pop_sound", petz.settings.max_hear_distance)
+			local converted_entity = converted_pet:get_luaentity()
+			converted_entity.tamed = true
+			kitz.remember(converted_entity, "tamed", converted_entity.tamed)
+			converted_entity.owner = player_name
+			kitz.remember(converted_entity, "owner", converted_entity.owner)
+			kitz.remove_mob(self)
+			local new_pet_name = petz.first_to_upper(converted_entity.type)
+			minetest.chat_send_player(player_name , S("The").." "..S(old_pet_name).." "..S("turn into").." "..S(new_pet_name))
+		end
 	else
 		minetest.chat_send_player(player_name , S("The").." "..S(old_pet_name).." "..S("is turning into another animal")..".")
 		kitz.make_sound("object", self.object, "petz_"..self.type.."_moaning", petz.settings.max_hear_distance)

--- a/petz/api/api_horseshoes.lua
+++ b/petz/api/api_horseshoes.lua
@@ -48,9 +48,10 @@ petz.horseshoes_reset = function(self)
 	local pos = self.object:get_pos()
 	for i = 1, self.horseshoes do
 		obj = minetest.add_item(pos, "petz:horseshoe")
-		kitz.drop_velocity(obj)
+		if obj then
+			kitz.drop_velocity(obj)
+		end
 	end
 	self.horseshoes = kitz.remember(self, "horseshoes", 0)
 	kitz.make_sound("object", self.object, "petz_pop_sound", petz.settings.max_hear_distance)
 end
-

--- a/petz/api/api_wagon.lua
+++ b/petz/api/api_wagon.lua
@@ -9,16 +9,18 @@ petz.put_wagon = function(self, clicker)
 	local pos = self.object:get_pos()
 	local rotation = self.object:get_rotation()
 	local wagon_obj = minetest.add_entity(pos, "petz:wagon", nil)
-	wagon_obj:set_attach(self.object, "", {x = 0, y = 0.0, z = 0}, rotation)
-	kitz.make_sound("object", self.object, "petz_pop_sound", petz.settings.max_hear_distance)
-	wagon_obj:set_properties({
-		visual_size = {
+	if wagon_obj then
+		wagon_obj:set_attach(self.object, "", {x = 0, y = 0.0, z = 0}, rotation)
+		kitz.make_sound("object", self.object, "petz_pop_sound", petz.settings.max_hear_distance)
+		wagon_obj:set_properties({
+			visual_size = {
 				x =1,
 				y = 1,
-		},
-	})
-	self.wagon = wagon_obj
-	local wielded_item = clicker:get_wielded_item()
-	wielded_item:take_item()
-	clicker:set_wielded_item(wielded_item)
+			},
+		})
+		self.wagon = wagon_obj
+		local wielded_item = clicker:get_wielded_item()
+		wielded_item:take_item()
+		clicker:set_wielded_item(wielded_item)
+	end
 end

--- a/petz/misc/items.lua
+++ b/petz/misc/items.lua
@@ -212,11 +212,13 @@ minetest.register_node("petz:fishtank", {
 				meta:set_string("has_fish", "true")
 				meta:set_string("fish_type", itemstack_name)
 				local fish_entity = minetest.add_entity({x=pos.x, y=pos.y, z=pos.z}, itemstack_name.."_entity_sprite")
-				local itemstack_meta = itemstack:get_meta()
-				fish_entity:set_properties({textures=itemstack_meta:get_string("textures").."^[transformFX"})
-				fish_entity:set_sprite({x=0, y=0}, 16, 1.0, false)
-				itemstack:take_item()
-				clicker:set_wielded_item(itemstack)
+				if fish_entity then
+					local itemstack_meta = itemstack:get_meta()
+					fish_entity:set_properties({textures=itemstack_meta:get_string("textures").."^[transformFX"})
+					fish_entity:set_sprite({x=0, y=0}, 16, 1.0, false)
+					itemstack:take_item()
+					clicker:set_wielded_item(itemstack)
+				end
 			end
 		elseif ((itemstack_name == "mobs:net") or (itemstack_name == "fireflies:bug_net")
 			or (itemstack_name == "petz:net")) and (has_fish == "true") then
@@ -414,7 +416,7 @@ for i=1, 2 do
 			local ent = minetest.add_entity(pos, "petz:"..bottled_mob, '{owner ='.. meta:get_string("owner")..', tamed = true}')
 			local texture_no = meta:get_int("petz:texture_no")
 			--minetest.chat_send_all("texture= "..tostring(meta:get_int("petz:texture_no")))
-			if texture_no then
+			if ent and texture_no then
 				local ent_ref = ent:get_luaentity()
 				if texture_no == 0 then
 					texture_no = math.random(1, #ent_ref.textures)

--- a/petz/misc/nodes.lua
+++ b/petz/misc/nodes.lua
@@ -218,10 +218,13 @@ minetest.register_node("petz:chicken_nest_egg", {
 			if not minetest.registered_entities["petz:chicken"] then
 				return
 			end
-			local entity = minetest.add_entity(pos_above, "petz:chicken"):get_luaentity()
-			entity.is_baby = kitz.remember(entity, "is_baby", true) --it is a baby
-			entity.growth_time = kitz.remember(entity, "growth_time", 0.0) --the chicken to grow
-			minetest.set_node(pos, {name= "petz:ducky_nest"})
+			local obj = minetest.add_entity(pos_above, "petz:chicken")
+			if obj then
+				local entity = obj:get_luaentity()
+				entity.is_baby = kitz.remember(entity, "is_baby", true) --it is a baby
+				entity.growth_time = kitz.remember(entity, "growth_time", 0.0) --the chicken to grow
+				minetest.set_node(pos, {name= "petz:ducky_nest"})
+			end
 			return true
 		end
 	end,


### PR DESCRIPTION
`minetest.add_entity` and `minetest.add_item` can return `nil` if the creation of the entity fails, which can result in crashes. this adds nil checks to prevent such crashes. 