### PR TITLE
add nil check to prevent crash when squirrel is near an unloaded block

### DIFF
--- a/petz/brains/bh_arboreal.lua
+++ b/petz/brains/bh_arboreal.lua
@@ -76,7 +76,7 @@ function petz.lq_climb(self)
 		local node_front_top_name, front_top_pos, node = petz.node_name_in(self, "front_top")
 		--minetest.chat_send_all(node_top_name)
 		if node_top_name and minetest.registered_nodes[node_top_name]
-			and (petz.is_tree_like(node)) then
+			and node_front_top_name and (petz.is_tree_like(node)) then
 				local climb = false
 				local climb_pos
 				for i =1, 8 do


### PR DESCRIPTION
`petz.node_node_name_in` can return `nil`, resulting in a crash:

```
2023-05-14 13:07:16: ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod 'petz' in callback luaentity_Step(): ...netest_live/bin/../mods/petz/petz/brains/bh_arboreal.lua:21: attempt to index local 'node' (a nil value)
2023-05-14 13:07:16: ERROR[Main]: stack traceback:
2023-05-14 13:07:16: ERROR[Main]: ...netest_live/bin/../mods/petz/petz/brains/bh_arboreal.lua:21: in function 'is_tree_like'
2023-05-14 13:07:16: ERROR[Main]: ...netest_live/bin/../mods/petz/petz/brains/bh_arboreal.lua:79: in function 'func'
2023-05-14 13:07:16: ERROR[Main]: .../mt/5.6.1/Minetest_live/bin/../mods/petz/kitz/engine.lua:652: in function 'execute_queues'
2023-05-14 13:07:16: ERROR[Main]: .../mt/5.6.1/Minetest_live/bin/../mods/petz/kitz/engine.lua:835: in function 'stepfunc'
2023-05-14 13:07:16: ERROR[Main]: ...test_live/bin/../mods/petz/petz/petz/squirrel_mobkit.lua:84: in function 'func'
2023-05-14 13:07:16: ERROR[Main]: ...inetest_live/bin/../builtin/profiler/instrumentation.lua:107: in function 'old_on_step'
```