### PR TITLE
correctly scale fall damage based on velocity change

### DIFF
--- a/kitz/engine.lua
+++ b/kitz/engine.lua
@@ -762,7 +762,8 @@ function kitz.vitals(self)
 	local vel = self.object:get_velocity()
 	local velocity_delta = abs(self.lastvelocity.y - vel.y)
 	if velocity_delta > kitz.safe_velocity then
-		kitz.hurt(self, floor(self.max_hp * min(1, velocity_delta/kitz.terminal_velocity)), "terminal velocity")
+		local damage_ratio = min(1, (velocity_delta - kitz.safe_velocity)/(kitz.terminal_velocity - kitz.safe_velocity))
+		kitz.hurt(self, floor(self.max_hp * damage_ratio), "terminal velocity")
 	end
 
 	-- vitals: oxygen


### PR DESCRIPTION
in the current fall damage calculation, if a petz falls slightly more than the safe distance (say, 6 nodes), it will lose half of its life. this PR correctly scales the damage if the petz falls between the safe and fatal distance. 